### PR TITLE
#SB-312: Use the github-release-plugin to create releases available via Github

### DIFF
--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -381,7 +381,7 @@
 
                 <executions>
                     <execution>
-                        <phase>deploy</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>release</goal>
                         </goals>


### PR DESCRIPTION
Reverting the phase back to "package". Not optimal in any way, but will work.
